### PR TITLE
Add possibility to add not centered position to content

### DIFF
--- a/Pod/Tests/Specs/ContentSpec.swift
+++ b/Pod/Tests/Specs/ContentSpec.swift
@@ -23,11 +23,19 @@ class ContentSpec: QuickSpec {
             superview.addSubview(content.view)
           }
 
+          it("changes center correctly") {
+            let center = position.originInFrame(superview.bounds)
+
+            content.layout()
+            expect(content.view.center).to(equal(center))
+          }
+
           it("changes origin correctly") {
+            content.centered = false
             let origin = position.originInFrame(superview.bounds)
 
             content.layout()
-            expect(content.view.center).to(equal(origin))
+            expect(content.view.frame.origin).to(equal(origin))
           }
         }
 

--- a/Source/Content.swift
+++ b/Source/Content.swift
@@ -1,13 +1,10 @@
 import UIKit
 import Cartography
 
-import UIKit
-import Cartography
-
 public class Content: NSObject {
 
   public var view: UIView
-  public var centered: Bool = true
+  public var centered: Bool
 
   public var position: Position {
     didSet {

--- a/Source/Content.swift
+++ b/Source/Content.swift
@@ -1,9 +1,13 @@
 import UIKit
 import Cartography
 
+import UIKit
+import Cartography
+
 public class Content: NSObject {
 
   public var view: UIView
+  public var centered: Bool = true
 
   public var position: Position {
     didSet {
@@ -14,9 +18,10 @@ public class Content: NSObject {
   public private(set) var initialPosition: Position
   private let group = ConstraintGroup()
 
-  public init(view: UIView, position: Position) {
+  public init(view: UIView, position: Position, centered: Bool = true) {
     self.view = view
     self.position = position
+    self.centered = centered
     initialPosition = position.positionCopy
 
     super.init()
@@ -30,8 +35,17 @@ public class Content: NSObject {
   public func layout() {
     if let superview = view.superview {
       constrain(view, replace: group) { [unowned self] view in
-        view.centerY  == view.superview!.bottom * self.position.top
-        view.centerX == view.superview!.right * self.position.left
+        let x = self.position.left == 0.0 ? view.superview!.left * 1.0 :
+          view.superview!.right * self.position.left
+        let y = self.position.top == 0.0 ? view.superview!.top * 1.0 :
+          view.superview!.bottom * self.position.top
+        if self.centered {
+          view.centerX == x
+          view.centerY  == y
+        } else {
+          view.left == x
+          view.top == y
+        }
       }
       view.layoutIfNeeded()
     }


### PR DESCRIPTION
Before when you create `Content` view model for view with some `Position` it assumed that it's position of the view's center. Now it could also be left/top position. 