### PR TITLE
Remove tests for when animation is playing

### DIFF
--- a/Pod/Tests/Specs/Animations/DissolveAnimationSpec.swift
+++ b/Pod/Tests/Specs/Animations/DissolveAnimationSpec.swift
@@ -79,23 +79,6 @@ class DissolveAnimationSpec: QuickSpec {
             expect(Double(view.alpha)) ≈ Double(0.0)
           }
         }
-
-        context("with playing animations") {
-          beforeEach {
-            superview.addSubview(view)
-            view.alpha = 1.0
-            UIView.animateWithDuration(10.0, animations: {
-              view.frame = CGRectZero
-            })
-          }
-
-          it("doesn't change alpha") {
-            let offsetRatio: CGFloat = 0.4
-
-            animation.moveWith(offsetRatio)
-            expect(Double(view.alpha)) ≈ Double(1.0)
-          }
-        }
       }
     }
   }

--- a/Pod/Tests/Specs/Animations/PopAnimationSpec.swift
+++ b/Pod/Tests/Specs/Animations/PopAnimationSpec.swift
@@ -57,16 +57,6 @@ class PopAnimationSpec: QuickSpec {
             expect(Double(view.alpha)) ≈ Double(1.0)
           }
         }
-
-        context("with playing animations") {
-          beforeEach {
-            superview.addSubview(view)
-            view.alpha = 1.0
-            UIView.animateWithDuration(10.0, animations: {
-              view.frame = CGRectZero
-            })
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
For some reason tests don't pass (sometimes) when we test behaviour during animation execution. So I've decided to remove it for now.