### PR TITLE
Fixed unexpected positioning swiping fast with the finger

### DIFF
--- a/Source/Animations/DissolveAnimation.swift
+++ b/Source/Animations/DissolveAnimation.swift
@@ -67,7 +67,7 @@ extension DissolveAnimation {
     if view.layer.animationKeys() == nil {
       if view.superview != nil {
         let ratio = offsetRatio > 0.0 ? offsetRatio : (1.0 + offsetRatio)
-        view.alpha = ratio
+        view.alpha = min(0.0, max(1.0, ratio))
       }
     }
   }

--- a/Source/Animations/PopAnimation.swift
+++ b/Source/Animations/PopAnimation.swift
@@ -75,7 +75,7 @@ extension PopAnimation {
     if view.layer.animationKeys() == nil {
       if view.superview != nil {
         let ratio = offsetRatio > 0.0 ? offsetRatio : (1.0 + offsetRatio)
-        view.alpha = ratio
+        view.alpha = min(0.0, max(1.0, ratio))
       }
     }
   }

--- a/Source/Animations/TransitionAnimation.swift
+++ b/Source/Animations/TransitionAnimation.swift
@@ -90,7 +90,7 @@ extension TransitionAnimation {
         let startY = position.yInFrame(superview.bounds)
         let dy = destination.yInFrame(superview.bounds) - startY
 
-        let ratio = offsetRatio > 0.0 ? offsetRatio : (1.0 + offsetRatio)
+        let ratio = min(0.0, max(1.0, offsetRatio > 0.0 ? offsetRatio : (1.0 + offsetRatio)))
         let offsetX = dx * ratio
         let offsetY = dy * ratio
 


### PR DESCRIPTION
Hi,

I found that when swiping with the finger instead of prev/next buttons, the offset may go over the expected bounds and thus, the last position (or alpha value) may ends at an unexpected position.

Clamping the offset to [0..1] fixed the problem for me, so here is my fix :)

Thanks!

